### PR TITLE
Use shell chdir argument.

### DIFF
--- a/roles/bundle_install/tasks/main.yml
+++ b/roles/bundle_install/tasks/main.yml
@@ -1,2 +1,4 @@
 - name: execute bundle install
-  shell: cd ./{{ appname }} && bundle install --path=vendor/bundle
+  shell: bundle install --path=vendor/bundle
+  args:
+    chdir: ./{{ appname }}


### PR DESCRIPTION
chdir should take care of `cd`ing into the directory before running the shell command.
